### PR TITLE
Add cookiecutter input to specify multiple test cases

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,6 +2,8 @@
   "name": "the-package",
   "slug": "the-package",
 
+  "test_cases": "defaults",
+
   "add_golden": "y",
 
   "copyright_holder": "VSHN AG <info@vshn.ch>",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+test_cases = "{{ cookiecutter.test_cases }}"
+
+tests_dir = Path("tests")
+tests_dir.mkdir(exist_ok=True)
+
+for case in test_cases.split(" "):
+    f = tests_dir / f"{case}.yml"
+    f.touch()

--- a/{{ cookiecutter.slug }}/.github/workflows/test.yaml
+++ b/{{ cookiecutter.slug }}/.github/workflows/test.yaml
@@ -1,3 +1,4 @@
+{%- set test_cases = cookiecutter.test_cases.split(" ") -%}
 name: Pull Request
 on:
   pull_request:
@@ -32,7 +33,9 @@ jobs:
     strategy:
       matrix:
         instance:
-          - defaults
+{%- for instance in test_cases %}
+          - {{ instance }}
+{%- endfor %}
     defaults:
       run:
         working-directory: {% raw %}${{ env.COMPONENT_NAME }}{% endraw %}
@@ -48,7 +51,9 @@ jobs:
     strategy:
       matrix:
         instance:
-          - defaults
+{%- for instance in test_cases %}
+          - {{ instance }}
+{%- endfor %}
     defaults:
       run:
         working-directory: {% raw %}${{ env.COMPONENT_NAME }}{% endraw %}

--- a/{{ cookiecutter.slug }}/Makefile.vars.mk
+++ b/{{ cookiecutter.slug }}/Makefile.vars.mk
@@ -1,3 +1,4 @@
+{%- set test_cases = cookiecutter.test_cases.split(" ") -%}
 # Commodore takes the root dir name as the package name
 PACKAGE_NAME ?= $(shell basename ${PWD} | sed s/package-//)
 
@@ -27,9 +28,9 @@ ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 35729:35729 --publish 202
 COMMODORE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) docker.io/projectsyn/commodore:latest
 COMPILE_CMD    ?= $(COMMODORE_CMD) package compile . $(commodore_args)
 
-instance ?= defaults
+instance ?= {{ test_cases[0] }}
 {%- if cookiecutter.add_golden == "y" %}
-test_instances = tests/defaults.yml
+test_instances ={% for instance in test_cases %} tests/{{instance}}.yml{% endfor %}
 {%- endif %}
 
 # We default to expecting a class matching the package name


### PR DESCRIPTION
The template expects test case names to be separated by spaces.

Commodore support for generating packages with additional test cases: https://github.com/projectsyn/commodore/pull/510




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
