### PR TITLE
Run package compile in subdirectory `tmp`

### DIFF
--- a/{{ cookiecutter.slug }}/.gitignore
+++ b/{{ cookiecutter.slug }}/.gitignore
@@ -3,6 +3,7 @@
 /compiled/
 /dependencies/
 /inventory/
+/tmp/
 /vendor/
 /jsonnetfile.json
 /jsonnetfile.lock.json

--- a/{{ cookiecutter.slug }}/Makefile
+++ b/{{ cookiecutter.slug }}/Makefile
@@ -46,11 +46,11 @@ test: .compile ## Compile the package
 gen-golden: clean .compile ## Update the reference version for target `golden-diff`.
 	@rm -rf tests/golden/$(instance)
 	@mkdir -p tests/golden/$(instance)
-	@cp -R compiled/. tests/golden/$(instance)/.
+	@cp -R tmp/compiled/. tests/golden/$(instance)/.
 
 .PHONY: golden-diff
 golden-diff: clean .compile ## Diff compile output against the reference version. Review output and run `make gen-golden golden-diff` if this target fails.
-	@git diff --exit-code --minimal --no-index -- tests/golden/$(instance) compiled/
+	@git diff --exit-code --minimal --no-index -- tests/golden/$(instance) tmp/compiled/
 
 .PHONY: golden-diff-all
 golden-diff-all: recursive_target=golden-diff

--- a/{{ cookiecutter.slug }}/Makefile.vars.mk
+++ b/{{ cookiecutter.slug }}/Makefile.vars.mk
@@ -26,7 +26,7 @@ ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 35729:35729 --publish 202
 
 
 COMMODORE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) docker.io/projectsyn/commodore:latest
-COMPILE_CMD    ?= $(COMMODORE_CMD) package compile . $(commodore_args)
+COMPILE_CMD    ?= $(COMMODORE_CMD) -d ./tmp package compile . $(commodore_args)
 
 instance ?= {{ test_cases[0] }}
 {%- if cookiecutter.add_golden == "y" %}


### PR DESCRIPTION
Otherwise reclass gets very confused because it finds multiple `.yamllint.yml` files which it treats as classes because we symlink the package to `inventory/classes/` for compilation, which also makes all the components stored in `dependencies/` available in the hierarchy indirectly.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
