### PR TITLE
Don't specify custom working directory for Commodore

### DIFF
--- a/{{ cookiecutter.slug }}/.gitignore
+++ b/{{ cookiecutter.slug }}/.gitignore
@@ -3,7 +3,6 @@
 /compiled/
 /dependencies/
 /inventory/
-/tmp/
 /vendor/
 /jsonnetfile.json
 /jsonnetfile.lock.json

--- a/{{ cookiecutter.slug }}/Makefile
+++ b/{{ cookiecutter.slug }}/Makefile
@@ -46,11 +46,11 @@ test: .compile ## Compile the package
 gen-golden: clean .compile ## Update the reference version for target `golden-diff`.
 	@rm -rf tests/golden/$(instance)
 	@mkdir -p tests/golden/$(instance)
-	@cp -R tmp/compiled/. tests/golden/$(instance)/.
+	@cp -R compiled/. tests/golden/$(instance)/.
 
 .PHONY: golden-diff
 golden-diff: clean .compile ## Diff compile output against the reference version. Review output and run `make gen-golden golden-diff` if this target fails.
-	@git diff --exit-code --minimal --no-index -- tests/golden/$(instance) tmp/compiled/
+	@git diff --exit-code --minimal --no-index -- tests/golden/$(instance) compiled/
 
 .PHONY: golden-diff-all
 golden-diff-all: recursive_target=golden-diff

--- a/{{ cookiecutter.slug }}/Makefile.vars.mk
+++ b/{{ cookiecutter.slug }}/Makefile.vars.mk
@@ -26,7 +26,7 @@ ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 35729:35729 --publish 202
 
 
 COMMODORE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) docker.io/projectsyn/commodore:latest
-COMPILE_CMD    ?= $(COMMODORE_CMD) -d ./tmp package compile . $(commodore_args)
+COMPILE_CMD    ?= $(COMMODORE_CMD) package compile . $(commodore_args)
 
 instance ?= {{ test_cases[0] }}
 {%- if cookiecutter.add_golden == "y" %}


### PR DESCRIPTION
This didn't actually fix the issue of ending up with an infinitely deep inventory directory structure, since we still recursively include the inventory even if we compile in the `tmp/` subdirectory.

Instead, we've now modified `commodore package compile` to create a temp directory outside of the package for the compilation, see https://github.com/projectsyn/commodore/pull/514.

This reverts commit 266ea2b23d7725bc0a711eadff4b8f8d919c115e / #5 




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
