### PR TITLE
Change Antora name to include a `package-` prefix

### DIFF
--- a/{{ cookiecutter.slug }}/docs/antora.yml
+++ b/{{ cookiecutter.slug }}/docs/antora.yml
@@ -1,4 +1,4 @@
-name: {{ cookiecutter.slug }}
+name: package-{{ cookiecutter.slug }}
 title: {{ cookiecutter.name }}
 version: master
 start_page: ROOT:index.adoc


### PR DESCRIPTION
This should avoid collisions when importing both component and package
documentation through Antora.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
