### PR TITLE
Configure GitHub action to run `commodore package sync`

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,33 +5,9 @@ on:
 
 jobs:
   sync_dry_run:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.commodore-venv/
-          key: ${{ runner.os }}-commodore-${{ hashFiles('requirements.txt') }}
-      - name: Install Commodore
-        run: |
-          python3 -m venv ~/.commodore-venv/
-          source ~/.commodore-venv/bin/activate
-          pip install -r requirements.txt
-      - name: Configure Git
-        run: |
-          git config --global user.name "$GITHUB_ACTOR"
-          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.5.4
-        with:
-            ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Run Commodore package sync
-        env:
-          COMMODORE_GITHUB_TOKEN: ${{ secrets.COMMODORE_GITHUB_TOKEN }}
-        run: |
-          . ~/.commodore-venv/bin/activate
-          commodore package sync packages.yaml --dry-run --pr-label template-sync --pr-branch template-sync
+    uses: ./.github/workflows/sync_base.yaml
+    with:
+      sync_args: '--dry-run'
+    secrets:
+      gh_token: ${{ secrets.COMMODORE_GITHUB_TOKEN }}
+      ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,37 @@
+name: Sync (dry-run)
+
+on:
+  pull_request: {}
+
+jobs:
+  sync_dry_run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.commodore-venv/
+          key: ${{ runner.os }}-commodore-${{ hashFiles('requirements.txt') }}
+      - name: Install Commodore
+        run: |
+          python3 -m venv ~/.commodore-venv/
+          source ~/.commodore-venv/bin/activate
+          pip install -r requirements.txt
+      - name: Configure Git
+        run: |
+          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+            ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Run Commodore package sync
+        env:
+          COMMODORE_GITHUB_TOKEN: ${{ secrets.COMMODORE_GITHUB_TOKEN }}
+        run: |
+          . ~/.commodore-venv/bin/activate
+          commodore package sync packages.yaml --dry-run --pr-label template-sync --pr-branch template-sync

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '{{ cookiecutter.slug }}/**'
+      - 'hooks/**'
 
 jobs:
   sync:

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -1,0 +1,40 @@
+name: Sync
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.commodore-venv/
+          key: ${{ runner.os }}-commodore-${{ hashFiles('requirements.txt') }}
+      - name: Install Commodore
+        run: |
+          python3 -m venv ~/.commodore-venv/
+          source ~/.commodore-venv/bin/activate
+          pip install -r requirements.txt
+      - name: Configure Git
+        run: |
+          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+            ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Run Commodore package sync
+        env:
+          COMMODORE_GITHUB_TOKEN: ${{ secrets.COMMODORE_GITHUB_TOKEN }}
+        run: |
+          . ~/.commodore-venv/bin/activate
+          commodore package sync packages.yaml --pr-label template-sync --pr-branch template-sync

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -11,33 +11,9 @@ on:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.commodore-venv/
-          key: ${{ runner.os }}-commodore-${{ hashFiles('requirements.txt') }}
-      - name: Install Commodore
-        run: |
-          python3 -m venv ~/.commodore-venv/
-          source ~/.commodore-venv/bin/activate
-          pip install -r requirements.txt
-      - name: Configure Git
-        run: |
-          git config --global user.name "$GITHUB_ACTOR"
-          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.5.4
-        with:
-            ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Run Commodore package sync
-        env:
-          COMMODORE_GITHUB_TOKEN: ${{ secrets.COMMODORE_GITHUB_TOKEN }}
-        run: |
-          . ~/.commodore-venv/bin/activate
-          commodore package sync packages.yaml --pr-label template-sync --pr-branch template-sync
+    uses: ./.github/workflows/sync_base.yaml
+    with:
+      sync_args: ''
+    secrets:
+      gh_token: ${{ secrets.COMMODORE_GITHUB_TOKEN }}
+      ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/sync_base.yaml
+++ b/.github/workflows/sync_base.yaml
@@ -1,0 +1,46 @@
+name: Sync (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      sync_args:
+        required: true
+        type: string
+    secrets:
+      ssh_key:
+        required: true
+      gh_token:
+        required: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.commodore-venv/
+          key: ${{ runner.os }}-commodore-${{ hashFiles('requirements.txt') }}
+      - name: Install Commodore
+        run: |
+          python3 -m venv ~/.commodore-venv/
+          source ~/.commodore-venv/bin/activate
+          pip install -r requirements.txt
+      - name: Configure Git
+        run: |
+          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+            ssh-private-key: ${{ secrets.ssh_key }}
+      - name: Run Commodore package sync
+        env:
+          COMMODORE_GITHUB_TOKEN: ${{ secrets.gh_token }}
+        run: |
+          . ~/.commodore-venv/bin/activate
+          commodore package sync packages.yaml --pr-label template-sync --pr-branch template-sync ${{ inputs.sync_args }}

--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ Additionally, the action can be triggered manually.
 To enable updates from the template for a package, you need to add the package in `packages.yaml` in format `<organization>/<repository-name>`.
 
 The GitHub action uses credentials (SSH key and personal access token) associated with account @vshnbot to push changes and create PRs on the managed package repositories.
+
+Please note that, while we provide a GitHub action which executes `commodore package sync --dry-run`, the PR action output will not preview of package updates caused by template changes in the PR, as `commodore package sync` updates each package to the template version indicated in the package's `cruft.json`.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,13 @@
 
 This repository is part of Project Syn.
 For documentation on Project Syn and this component, see https://syn.tools.
+
+## Template sync
+
+This repository contains a GitHub action which runs `commodore package sync`.
+The action is triggered when changes are pushed to the `main` branch.
+Additionally, the action can be triggered manually.
+
+To enable updates from the template for a package, you need to add the package in `packages.yaml` in format `<organization>/<repository-name>`.
+
+The GitHub action uses credentials (SSH key and personal access token) associated with account @vshnbot to push changes and create PRs on the managed package repositories.

--- a/packages.yaml
+++ b/packages.yaml
@@ -1,0 +1,2 @@
+---
+- projectsyn/package-monitoring

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+syn-commodore==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-syn-commodore==1.7.0
+syn-commodore==1.7.1


### PR DESCRIPTION
Add `packages.yaml` which contains the list of config package repositories on GitHub that should be kept updated.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
