### PR TITLE
Fix target commit for releases in GitHub action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,6 @@ jobs:
         with:
           body: ${{steps.build_changelog.outputs.changelog}}
           prerelease: "${{ contains(github.ref, '-rc') }}"
-          # Ensure target branch for release is "master"
-          commit: master
+          # Ensure target branch for release is "main"
+          commit: main
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We want the releases to be targeting branch `main`.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
